### PR TITLE
Feature/#9 filename

### DIFF
--- a/src/main/java/com/yapp/project/external/s3/S3Uploader.java
+++ b/src/main/java/com/yapp/project/external/s3/S3Uploader.java
@@ -58,9 +58,13 @@ public class S3Uploader {
     private Optional<File> convert(MultipartFile file) throws IOException {
         Calendar cal = Calendar.getInstance();
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd_HHmmSS");
-        String fileName = dateFormat.format(cal.getTime());  // 현재 시간으로 파일명 등록 -> 파일명 중복 방지
 
-        File convertFile = new File(fileName);
+        String originFileName = file.getOriginalFilename();
+        String ext = originFileName.substring(originFileName.lastIndexOf(".") + 1);
+
+        String newFileName = dateFormat.format(cal.getTime()) + "." + ext;  // 현재 시간으로 파일명 등록 -> 파일명 중복 방지
+
+        File convertFile = new File(newFileName);
         if(convertFile.createNewFile()) {
             try (FileOutputStream fos = new FileOutputStream(convertFile)) {
                 fos.write(file.getBytes());

--- a/src/main/java/com/yapp/project/external/s3/S3Uploader.java
+++ b/src/main/java/com/yapp/project/external/s3/S3Uploader.java
@@ -56,9 +56,9 @@ public class S3Uploader {
     }
 
     private Optional<File> convert(MultipartFile file) throws IOException {
-        Calendar cal = Calendar.getInstance()  ;
+        Calendar cal = Calendar.getInstance();
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd_HHmmSS");
-        String fileName = dateFormat.format(cal.getTime());
+        String fileName = dateFormat.format(cal.getTime());  // 현재 시간으로 파일명 등록 -> 파일명 중복 방지
 
         File convertFile = new File(fileName);
         if(convertFile.createNewFile()) {

--- a/src/main/java/com/yapp/project/external/s3/S3Uploader.java
+++ b/src/main/java/com/yapp/project/external/s3/S3Uploader.java
@@ -14,6 +14,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Optional;
 
 @Slf4j
@@ -54,7 +56,11 @@ public class S3Uploader {
     }
 
     private Optional<File> convert(MultipartFile file) throws IOException {
-        File convertFile = new File(file.getOriginalFilename());
+        Calendar cal = Calendar.getInstance()  ;
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd_HHmmSS");
+        String fileName = dateFormat.format(cal.getTime());
+
+        File convertFile = new File(fileName);
         if(convertFile.createNewFile()) {
             try (FileOutputStream fos = new FileOutputStream(convertFile)) {
                 fos.write(file.getBytes());


### PR DESCRIPTION
resolve #9 

- 파일 등록 시, local에 이미 같은 이름의 파일이 존재하면 파일 저장이 불가함.
- 따라서 현재 날짜와 시간을 기준으로 unique한 값의 파일명을 만들고 이 파일명을 s3에 업로드 하는 방식으로 로직 수정